### PR TITLE
change capital letter R in installation

### DIFF
--- a/installation-and-setup.md
+++ b/installation-and-setup.md
@@ -9,7 +9,7 @@ TH Rxjs lib can be consumed in many different ways, namely `ES6`, `CommonJS` and
 ### Install
 ```
 
-npm install Rxjs
+npm install rxjs
 
 ```
 
@@ -46,7 +46,7 @@ Same install as with ES6
 ### Install
 ```
 
-npm install Rxjs
+npm install rxjs
 
 ```
 


### PR DESCRIPTION
```npm install Rxjs``` for npm version ```5.6.0```  failed  with ``` 404 Not Found: Rxjs@latest```.

with lower case ```npm install rxjs``` works fine