### PR TITLE
Refactored code examples to be more accurate

### DIFF
--- a/observable-anatomy.md
+++ b/observable-anatomy.md
@@ -32,8 +32,8 @@ let stream$ = Rx.Observable.create((observer) => {
 })
 
 stream$.subscribe(
-   (data) => console.log('Data', data)),
-   (error) => console.log('Error', error)
+   (data) => console.log('Data', data),
+   (error) => console.log('Error', error))
 ```
 
 Lastly we have the **fnComplete** and it should be invoked when a stream is done and has no more values to emit. It is triggered by a call to `observer.complete()` like so:

--- a/producer.md
+++ b/producer.md
@@ -9,7 +9,7 @@ A producer have the task of producing the values emitted by an Observable
     }
  
     nextValue(){
-      return i++;
+      return this.i++;
     }
  }
 
@@ -19,10 +19,11 @@ And to use it
 
 ```
   let stream$ = Observable.create( (observer) => {
-    observer.next( Producer.nextValue() )
-    observer.next( Producer.nextValue() )
+    const producer = new Producer();
+    observer.next( producer.nextValue() )
+    observer.next( producer.nextValue() )
   })
 ```    
 
 In the [Observable Anatomy](/observable-anatomy.md) chapter there is no `Producer` in the examples but most `Observables` that are created by a helper method will have an internal `Producer` producing values that the observer emits using the `observer.next` method
- 
+


### PR DESCRIPTION
- Fixed a misplaced parentheses in observable-anatomy. 
- Should be after the error callback.

- Refactored the code example for producer to be more accurate.